### PR TITLE
Collect post date when scraping posts

### DIFF
--- a/lib/insta_scrape.rb
+++ b/lib/insta_scrape.rb
@@ -4,29 +4,29 @@ module InstaScrape
   extend Capybara::DSL
 
   #get a hashtag
-  def self.hashtag(hashtag)
+  def self.hashtag(hashtag, include_meta_data: false)
     visit "https://www.instagram.com/explore/tags/#{hashtag}/"
     @posts = []
-    scrape_posts
+    scrape_posts(include_meta_data: include_meta_data)
   end
 
   #long scrape a hashtag
-  def self.long_scrape_hashtag(hashtag, scrape_length)
+  def self.long_scrape_hashtag(hashtag, scrape_length, include_meta_data: false)
     visit "https://www.instagram.com/explore/tags/#{hashtag}/"
     @posts = []
-    long_scrape_posts(scrape_length)
+    long_scrape_posts(scrape_length, include_meta_data: include_meta_data)
   end
 
   #long scrape a hashtag
-  def self.long_scrape_user_posts(username, scrape_length)
+  def self.long_scrape_user_posts(username, scrape_length, include_meta_data: false)
     @posts = []
-    long_scrape_user_posts_method(username, scrape_length)
+    long_scrape_user_posts_method(username, scrape_length, include_meta_data: include_meta_data)
   end
 
   #get user info and posts
-  def self.long_scrape_user_info_and_posts(username, scrape_length)
+  def self.long_scrape_user_info_and_posts(username, scrape_length, include_meta_data: false)
     scrape_user_info(username)
-    long_scrape_user_posts_method(username, scrape_length)
+    long_scrape_user_posts_method(username, scrape_length, include_meta_data: include_meta_data)
     @user = InstaScrape::InstagramUserWithPosts.new(username, @image, @post_count, @follower_count, @following_count, @description, @posts)
   end
 
@@ -37,15 +37,15 @@ module InstaScrape
   end
 
   #get user info and posts
-  def self.user_info_and_posts(username)
+  def self.user_info_and_posts(username, include_meta_data: false)
     scrape_user_info(username)
-    scrape_user_posts(username)
+    scrape_user_posts(username, include_meta_data: false)
     @user = InstaScrape::InstagramUserWithPosts.new(username, @image, @post_count, @follower_count, @following_count, @description, @posts)
   end
 
   #get user posts only
-  def self.user_posts(username)
-    scrape_user_posts(username)
+  def self.user_posts(username, include_meta_data: false)
+    scrape_user_posts(username, include_meta_data: include_meta_data)
   end
 
   #get user follower count
@@ -74,14 +74,21 @@ module InstaScrape
 
   private
   #post iteration method
-  def self.iterate_through_posts
-    all("article div div div a").each do |post|
+  def self.iterate_through_posts(include_meta_data:)
+    posts = all("article div div div a").collect do |post|
+      { link: post["href"],
+        image: post.find("img")["src"]}
+    end
 
-      link = post["href"]
-      image = post.find("img")["src"]
-      info = InstaScrape::InstagramPost.new(link, image)
+    posts.each do |post|
+      if include_meta_data
+        visit(post[:link]) 
+        date = page.find('time')["datetime"]
+        info = InstaScrape::InstagramPost.new(post[:link], post[:image], date)
+      else
+        info = InstaScrape::InstagramPost.new(post[:link], post[:image])
+      end
       @posts << info
-
     end
 
     #log
@@ -108,7 +115,7 @@ module InstaScrape
   end
 
   #scrape posts
-  def self.scrape_posts
+  def self.scrape_posts(include_meta_data:)
     begin
       page.find('a', :text => "Load more", exact: true).click
       max_iteration = 10
@@ -120,15 +127,15 @@ module InstaScrape
         page.execute_script "window.scrollTo(0,(document.body.scrollHeight - 5000));"
         sleep 0.1
       end
-      iterate_through_posts
+      iterate_through_posts(include_meta_data: include_meta_data)
     rescue Capybara::ElementNotFound => e
       begin
-        iterate_through_posts
+        iterate_through_posts(include_meta_data: include_meta_data)
       end
     end
   end
 
-  def self.long_scrape_posts(scrape_length_in_seconds)
+  def self.long_scrape_posts(scrape_length_in_seconds, include_meta_data:)
     begin
       page.find('a', :text => "Load more", exact: true).click
       max_iteration = (scrape_length_in_seconds / 0.3)
@@ -145,24 +152,24 @@ module InstaScrape
         @loader << "."
         system "clear"
       end
-      iterate_through_posts
+      iterate_through_posts(include_meta_data: include_meta_data)
     rescue Capybara::ElementNotFound => e
       begin
-        iterate_through_posts
+        iterate_through_posts(include_meta_data: include_meta_data)
       end
     end
   end
 
-  def self.long_scrape_user_posts_method(username, scrape_length_in_seconds)
+  def self.long_scrape_user_posts_method(username, scrape_length_in_seconds, include_meta_data:)
     @posts = []
     visit "https://www.instagram.com/#{username}/"
-    long_scrape_posts(scrape_length_in_seconds)
+    long_scrape_posts(scrape_length_in_seconds, include_meta_data: include_meta_data)
   end
 
-  def self.scrape_user_posts(username)
+  def self.scrape_user_posts(username, include_meta_data:)
     @posts = []
     visit "https://www.instagram.com/#{username}/"
-    scrape_posts
+    scrape_posts(include_meta_data: include_meta_data)
   end
 
   #post logger

--- a/lib/models/instagram_post.rb
+++ b/lib/models/instagram_post.rb
@@ -1,7 +1,8 @@
 class InstaScrape::InstagramPost
-  attr_accessor :link, :image
-  def initialize(link, image)
+  attr_accessor :link, :image, :date
+  def initialize(link, image, date=nil)
     @image = image
     @link = link
+    @date = date
   end
 end

--- a/spec/insta_scrape_spec.rb
+++ b/spec/insta_scrape_spec.rb
@@ -26,21 +26,42 @@ describe InstaScrape do
     expect(scrape_result.posts.length).to be > 20
   end
 
-  it 'connects to user\'s instagram scrapes just posts' do
-    scrape_result = InstaScrape.user_posts('foofighters')
-    expect(scrape_result[0].link).to_not eq(nil)
-    expect(scrape_result[0].image).to_not eq(nil)
+  describe '#user_posts' do
+    it 'connects to user\'s instagram scrapes just posts' do
+      scrape_result = InstaScrape.user_posts('foofighters')
+      expect(scrape_result[0].link).to_not eq(nil)
+      expect(scrape_result[0].image).to_not eq(nil)
+    end
+
+    it 'returns extra data for each post' do
+      scrape_result = InstaScrape.user_posts('foofighters', include_meta_data: true)
+      expect(scrape_result[0].date).to_not eq(nil)
+    end
   end
 
-  it 'connects to instagram hashtag long_scrapes \'test\' hashtag and gets over 2k posts' do
-    scrape_result = InstaScrape.long_scrape_hashtag('test', 60)
-    expect(scrape_result.length).to be > 2000
+  describe '#long_scrape_hashtag' do
+    it 'connects to instagram hashtag long_scrapes \'test\' hashtag and gets over 2k posts' do
+      scrape_result = InstaScrape.long_scrape_hashtag('test', 60)
+      expect(scrape_result.length).to be > 2000
+    end
+
+    it 'returns extra data for each post' do
+      scrape_result = InstaScrape.long_scrape_hashtag('test', 1, include_meta_data: true)
+      expect(scrape_result[0].date).to_not eq(nil)
+    end
   end
 
-  it 'connects to instagram hashtag long_scrapes a user and gets all posts' do
-    post_count = InstaScrape.user_post_count('foofighters')
-    scrape_result = InstaScrape.long_scrape_user_posts('foofighters', 30)
-    expect(scrape_result.length.to_s).to be === post_count
+  describe '#long_scrape_users' do
+    it 'connects to instagram hashtag long_scrapes a user and gets all posts' do
+      post_count = InstaScrape.user_post_count('foofighters')
+      scrape_result = InstaScrape.long_scrape_user_posts('foofighters', 30)
+      expect(scrape_result.length.to_s).to be === post_count
+    end
+
+    it 'returns extra data for each post' do
+      scrape_result = InstaScrape.long_scrape_user_posts('foofighters', 1, include_meta_data: true)
+      expect(scrape_result[0].date).to_not eq(nil)
+    end
   end
 
   it 'connects to instagram hashtag long_scrapes a user info with posts and gets all of them' do


### PR DESCRIPTION
Add a switch to all public methods which collect posts.
This switch instructs the scraper to go through each individual post page and scrape the post date from there. The switch makes the methods run much slower, but it does give scope to collect
comments (which you couldn't otherwise do).

In terms of implementation, I considered creating a new public method which would collect extra information about posts. This seemed redundant since all of the other public methods were returning posts in slightly different ways, but each one could benefit from returning extra post data. I decided to add a switch to every public method which returned posts, called `include_meta_data` and set it to false by default, so that a user wouldn't have to use it if they didn't need it.

I've added three tests but just wanted to get your thoughts on this before adding more and updating the README. 

Thanks!
