### PR TITLE
Pull Post Text from Image Alt

### DIFF
--- a/lib/insta_scrape.rb
+++ b/lib/insta_scrape.rb
@@ -79,7 +79,9 @@ module InstaScrape
 
       link = post["href"]
       image = post.find("img")["src"]
-      info = InstaScrape::InstagramPost.new(link, image)
+      text = post.find("h1")
+      time = post.find("time")["datetime"]
+      info = InstaScrape::InstagramPost.new(link, image, text, time)
       @posts << info
 
     end

--- a/lib/insta_scrape.rb
+++ b/lib/insta_scrape.rb
@@ -79,7 +79,7 @@ module InstaScrape
     posts = all("article div div div a").collect do |post|
       { link: post["href"],
         image: post.find("img")["src"],
-        text: img["alt"]}
+        text: post.find("img")["alt"]}
     end
 
     posts.each do |post|

--- a/lib/insta_scrape.rb
+++ b/lib/insta_scrape.rb
@@ -76,12 +76,11 @@ module InstaScrape
   #post iteration method
   def self.iterate_through_posts
     all("article div div div a").each do |post|
-
-      link = post["href"]
-      image = post.find("img")["src"]
-      text = post.find("h1")
-      time = post.find("time")["datetime"]
-      info = InstaScrape::InstagramPost.new(link, image, text, time)
+      link  = post["href"]
+      img   = post.find('img')
+      image = img["src"]
+      text  = img["alt"]
+      info  = InstaScrape::InstagramPost.new(link, image, text)
       @posts << info
 
     end

--- a/lib/models/instagram_post.rb
+++ b/lib/models/instagram_post.rb
@@ -1,5 +1,5 @@
 class InstaScrape::InstagramPost
-  attr_accessor :link, :image
+  attr_accessor :link, :image, :text
   def initialize(link, image, text=nil)
     @image = image
     @link = link

--- a/lib/models/instagram_post.rb
+++ b/lib/models/instagram_post.rb
@@ -1,7 +1,9 @@
 class InstaScrape::InstagramPost
   attr_accessor :link, :image
-  def initialize(link, image)
+  def initialize(link, image, text=nil, time=nil)
     @image = image
     @link = link
+    @text = text
+    @time = Time.new(time)
   end
 end

--- a/lib/models/instagram_post.rb
+++ b/lib/models/instagram_post.rb
@@ -1,9 +1,8 @@
 class InstaScrape::InstagramPost
   attr_accessor :link, :image
-  def initialize(link, image, text=nil, time=nil)
+  def initialize(link, image, text=nil)
     @image = image
     @link = link
     @text = text
-    @time = Time.new(time)
   end
 end


### PR DESCRIPTION
Instagram tucks the original post text into the image alt, making this a quick and dirty enhancement