### PR TITLE
Fix language problem with forcing en

### DIFF
--- a/lib/init/poltergeist.rb
+++ b/lib/init/poltergeist.rb
@@ -1,5 +1,7 @@
 Capybara.register_driver :poltergeist do |app|
-    Capybara::Poltergeist::Driver.new(app, :phantomjs => Phantomjs.path)
+  driver = Capybara::Poltergeist::Driver.new(app, :phantomjs => Phantomjs.path)
+  driver.add_header('Accept-Language', 'en')
+  driver
 end
 
 Capybara.default_driver = :poltergeist


### PR DESCRIPTION
I had a problem that posts was scraped only in first page (no scroll iteration).
It is caused by a language setting on environment, because DOM elements are queried with matching text.

For example

```ruby
page.find('a', :text => "Load more", exact: true).click
```

In japanese environment, not "Load more" but "さらに表示".

This PR fix it with forcing language to "en".