### PR TITLE
Suppress Capybara javascript errors

### DIFF
--- a/lib/init/poltergeist.rb
+++ b/lib/init/poltergeist.rb
@@ -1,5 +1,5 @@
 Capybara.register_driver :poltergeist do |app|
-  driver = Capybara::Poltergeist::Driver.new(app, :phantomjs => Phantomjs.path)
+  driver = Capybara::Poltergeist::Driver.new(app, :phantomjs => Phantomjs.path, :js_errors = false)
   driver.add_header('Accept-Language', 'en')
   driver
 end

--- a/lib/init/poltergeist.rb
+++ b/lib/init/poltergeist.rb
@@ -1,5 +1,5 @@
 Capybara.register_driver :poltergeist do |app|
-  driver = Capybara::Poltergeist::Driver.new(app, :phantomjs => Phantomjs.path, :js_errors = false)
+  driver = Capybara::Poltergeist::Driver.new(app, :phantomjs => Phantomjs.path, :js_errors => false)
   driver.add_header('Accept-Language', 'en')
   driver
 end


### PR DESCRIPTION
This PR adds `js_errors: false` option to driver initialization so it won't throw exceptions when there is any javascript errors on Instagram side. Fixes #18 