### PR TITLE
[FIX] parsing of description at user's page

### DIFF
--- a/lib/insta_scrape.rb
+++ b/lib/insta_scrape.rb
@@ -120,7 +120,7 @@ module InstaScrape
       @follower_count = get_span_value(follower_count_html)
       following_count_html = page.find('span', :text => "following", exact: true)['innerHTML']
       @following_count = get_span_value(following_count_html)
-      description = page.find('h2').first(:xpath,".//..")['innerHTML']
+      description = page.find(:xpath, '//header/section/div[2]')['innerHTML']
       @description = Nokogiri::HTML(description).text
     end
   end


### PR DESCRIPTION
Quick fix of parsing of description at user's page as the original one ceased to work.