### PR TITLE
[ADD] check if account is private

### DIFF
--- a/lib/insta_scrape.rb
+++ b/lib/insta_scrape.rb
@@ -3,6 +3,8 @@ require "dependencies"
 module InstaScrape
   extend Capybara::DSL
 
+  class PrivateAccountError < StandardError; end
+
   #get a hashtag
   def self.hashtag(hashtag, include_meta_data: false)
     visit "https://www.instagram.com/explore/tags/#{hashtag}/"
@@ -128,6 +130,7 @@ module InstaScrape
   #scrape posts
   def self.scrape_posts(include_meta_data:)
     begin
+      check_if_private_account(page)
       page.find('a', :text => "Load more", exact: true).click
       max_iteration = 10
       iteration = 0
@@ -148,6 +151,7 @@ module InstaScrape
 
   def self.long_scrape_posts(scrape_length_in_seconds, include_meta_data:)
     begin
+      check_if_private_account(page)
       page.find('a', :text => "Load more", exact: true).click
       max_iteration = (scrape_length_in_seconds / 0.3)
       iteration = 0
@@ -207,4 +211,12 @@ module InstaScrape
     return element[/#{begin_split}(.*?)#{end_split}/m, 1]
   end
 
+  #notify that the account requested is private
+  def self.check_if_private_account(page)
+    if page.find('h2').text.strip.eql?('This Account is Private')
+      raise PrivateAccountError.new('This account is private!')
+    else
+      false
+    end
+  end
 end

--- a/lib/insta_scrape.rb
+++ b/lib/insta_scrape.rb
@@ -3,7 +3,9 @@ require "dependencies"
 module InstaScrape
   extend Capybara::DSL
 
-  class PrivateAccountError < StandardError; end
+  class InstaScrapeError < StandardError; end
+  class PrivateAccountError < InstaScrapeError; end
+  class NoPostsError < InstaScrapeError; end
 
   #get a hashtag
   def self.hashtag(hashtag, include_meta_data: false)
@@ -130,7 +132,7 @@ module InstaScrape
   #scrape posts
   def self.scrape_posts(include_meta_data:)
     begin
-      check_if_private_account(page)
+      check_account(page)
       page.find('a', :text => "Load more", exact: true).click
       max_iteration = 10
       iteration = 0
@@ -151,7 +153,7 @@ module InstaScrape
 
   def self.long_scrape_posts(scrape_length_in_seconds, include_meta_data:)
     begin
-      check_if_private_account(page)
+      check_account(page)
       page.find('a', :text => "Load more", exact: true).click
       max_iteration = (scrape_length_in_seconds / 0.3)
       iteration = 0
@@ -212,9 +214,12 @@ module InstaScrape
   end
 
   #notify that the account requested is private
-  def self.check_if_private_account(page)
-    if page.find('h2').text.strip.eql?('This Account is Private')
+  def self.check_account(page)
+    title = page.find('h2').text.strip
+    if title.eql?('This Account is Private')
       raise PrivateAccountError.new('This account is private!')
+    elsif title.eql?('No posts yet.')
+      raise NoPostsError.new('This account has no posts!')
     else
       false
     end

--- a/spec/insta_scrape_spec.rb
+++ b/spec/insta_scrape_spec.rb
@@ -45,6 +45,12 @@ describe InstaScrape do
         InstaScrape.user_posts('patrik_dal_nic')
       }.to raise_error(InstaScrape::PrivateAccountError)
     end
+
+    it 'detects empty account' do
+      expect {
+        InstaScrape.user_posts('usudhedycgfjfj')
+      }.to raise_error(InstaScrape::NoPostsError)
+    end
   end
 
   describe '#long_scrape_hashtag' do

--- a/spec/insta_scrape_spec.rb
+++ b/spec/insta_scrape_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe InstaScrape do
-
   it 'has a version number' do
     expect(InstaScrape::VERSION).not_to be nil
   end
@@ -40,6 +39,12 @@ describe InstaScrape do
       expect(scrape_result[0].hi_res_image).to_not eq(nil)
       expect(scrape_result[0].likes).to_not eq(nil)
     end
+
+    it 'detects private account' do
+      expect {
+        InstaScrape.user_posts('patrik_dal_nic')
+      }.to raise_error(InstaScrape::PrivateAccountError)
+    end
   end
 
   describe '#long_scrape_hashtag' do
@@ -73,6 +78,12 @@ describe InstaScrape do
       expect(scrape_result[0].hi_res_image).to_not eq(nil)
       expect(scrape_result[0].likes).to_not eq(nil)
     end
+
+    it 'detects private account' do
+      expect {
+        InstaScrape.long_scrape_user_posts('patrik_dal_nic', 30)
+      }.to raise_error(InstaScrape::PrivateAccountError)
+    end
   end
 
   it 'connects to instagram hashtag long_scrapes a user info with posts and gets all of them' do
@@ -105,5 +116,4 @@ describe InstaScrape do
     scrape_result = InstaScrape.user_description('foofighters')
     expect(scrape_result).to_not eq(nil)
   end
-
 end


### PR DESCRIPTION
Checks if the account is private before scraping posts, and if it is, it raises an exception to distinguish between this case and the case when capybara cannot found an element.